### PR TITLE
Add transform-es2015-duplicate-keys plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ module.exports = {
     require("babel-plugin-transform-es2015-classes"),
     require("babel-plugin-transform-es2015-object-super"),
     require("babel-plugin-transform-es2015-shorthand-properties"),
+    require("babel-plugin-transform-es2015-duplicate-keys"),
     require("babel-plugin-transform-es2015-computed-properties"),
     require("babel-plugin-transform-es2015-for-of"),
     require("babel-plugin-transform-es2015-sticky-regex"),

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "babel-plugin-transform-es2015-classes": "^6.3.13",
     "babel-plugin-transform-es2015-computed-properties": "^6.3.13",
     "babel-plugin-transform-es2015-destructuring": "^6.3.13",
+    "babel-plugin-transform-es2015-duplicate-keys": "^6.4.0",
     "babel-plugin-transform-es2015-for-of": "^6.3.13",
     "babel-plugin-transform-es2015-function-name": "^6.3.13",
     "babel-plugin-transform-es2015-literals": "^6.3.13",


### PR DESCRIPTION
This was added to babel-preset-es2015 by

https://github.com/babel/babel/commit/f01eaa8e475da669881b1d267eaad52144c7d3f9
